### PR TITLE
Notification 데이터 로드 및 리스트 화면에 처리

### DIFF
--- a/app/src/main/java/com/github/repo/data/datasource/GithubDataSource.kt
+++ b/app/src/main/java/com/github/repo/data/datasource/GithubDataSource.kt
@@ -1,5 +1,6 @@
 package com.github.repo.data.datasource
 
+import com.github.repo.data.dto.GithubIssueDto
 import com.github.repo.data.dto.GithubSearchDto
 import com.github.repo.data.dto.GithubNotificationDto
 import com.github.repo.data.network.GitHubService
@@ -15,4 +16,6 @@ class GithubDataSource(private val gitHubService: GitHubService) {
     suspend fun getNotifications(token: String): Result<List<GithubNotificationDto>>
         = runCatching { gitHubService.getNotifications(token) }
 
+    suspend fun getIssueFromNotification(url: String): Result<GithubIssueDto>
+            = runCatching { gitHubService.getIssueFromNotification(url) }
 }

--- a/app/src/main/java/com/github/repo/data/dto/GithubAssigneeDto.kt
+++ b/app/src/main/java/com/github/repo/data/dto/GithubAssigneeDto.kt
@@ -1,0 +1,43 @@
+package com.github.repo.data.dto
+
+
+import com.squareup.moshi.Json
+
+data class GithubAssigneeDto(
+    @Json(name = "avatar_url")
+    val avatarUrl: String,
+    @Json(name = "events_url")
+    val eventsUrl: String,
+    @Json(name = "followers_url")
+    val followersUrl: String,
+    @Json(name = "following_url")
+    val followingUrl: String,
+    @Json(name = "gists_url")
+    val gistsUrl: String,
+    @Json(name = "gravatar_id")
+    val gravatarId: String,
+    @Json(name = "html_url")
+    val htmlUrl: String,
+    @Json(name = "id")
+    val id: Int,
+    @Json(name = "login")
+    val login: String,
+    @Json(name = "node_id")
+    val nodeId: String,
+    @Json(name = "organizations_url")
+    val organizationsUrl: String,
+    @Json(name = "received_events_url")
+    val receivedEventsUrl: String,
+    @Json(name = "repos_url")
+    val reposUrl: String,
+    @Json(name = "site_admin")
+    val siteAdmin: Boolean,
+    @Json(name = "starred_url")
+    val starredUrl: String,
+    @Json(name = "subscriptions_url")
+    val subscriptionsUrl: String,
+    @Json(name = "type")
+    val type: String,
+    @Json(name = "url")
+    val url: String
+)

--- a/app/src/main/java/com/github/repo/data/dto/GithubCreatorDto.kt
+++ b/app/src/main/java/com/github/repo/data/dto/GithubCreatorDto.kt
@@ -1,0 +1,43 @@
+package com.github.repo.data.dto
+
+
+import com.squareup.moshi.Json
+
+data class GithubCreatorDto(
+    @Json(name = "avatar_url")
+    val avatarUrl: String,
+    @Json(name = "events_url")
+    val eventsUrl: String,
+    @Json(name = "followers_url")
+    val followersUrl: String,
+    @Json(name = "following_url")
+    val followingUrl: String,
+    @Json(name = "gists_url")
+    val gistsUrl: String,
+    @Json(name = "gravatar_id")
+    val gravatarId: String,
+    @Json(name = "html_url")
+    val htmlUrl: String,
+    @Json(name = "id")
+    val id: Int,
+    @Json(name = "login")
+    val login: String,
+    @Json(name = "node_id")
+    val nodeId: String,
+    @Json(name = "organizations_url")
+    val organizationsUrl: String,
+    @Json(name = "received_events_url")
+    val receivedEventsUrl: String,
+    @Json(name = "repos_url")
+    val reposUrl: String,
+    @Json(name = "site_admin")
+    val siteAdmin: Boolean,
+    @Json(name = "starred_url")
+    val starredUrl: String,
+    @Json(name = "subscriptions_url")
+    val subscriptionsUrl: String,
+    @Json(name = "type")
+    val type: String,
+    @Json(name = "url")
+    val url: String
+)

--- a/app/src/main/java/com/github/repo/data/dto/GithubIssueDto.kt
+++ b/app/src/main/java/com/github/repo/data/dto/GithubIssueDto.kt
@@ -1,0 +1,64 @@
+package com.github.repo.data.dto
+
+import com.squareup.moshi.Json
+
+data class GithubIssueDto(
+    @Json(name = "active_lock_reason")
+    val activeLockReason: Any?,
+    @Json(name = "assignee")
+    val assignee: GithubAssigneeDto,
+    @Json(name = "assignees")
+    val assignees: List<GithubAssigneeDto>,
+    @Json(name = "author_association")
+    val authorAssociation: String,
+    @Json(name = "body")
+    val body: String,
+    @Json(name = "closed_at")
+    val closedAt: Any?,
+    @Json(name = "closed_by")
+    val closedBy: Any?,
+    @Json(name = "comments")
+    val comments: Int,
+    @Json(name = "comments_url")
+    val commentsUrl: String,
+    @Json(name = "created_at")
+    val createdAt: String,
+    @Json(name = "events_url")
+    val eventsUrl: String,
+    @Json(name = "html_url")
+    val htmlUrl: String,
+    @Json(name = "id")
+    val id: Int,
+    @Json(name = "labels")
+    val labels: List<GithubLabelDto>,
+    @Json(name = "labels_url")
+    val labelsUrl: String,
+    @Json(name = "locked")
+    val locked: Boolean,
+    @Json(name = "milestone")
+    val milestone: GithubMilestoneDto,
+    @Json(name = "node_id")
+    val nodeId: String,
+    @Json(name = "number")
+    val number: Int,
+    @Json(name = "performed_via_github_app")
+    val performedViaGithubApp: Any?,
+    @Json(name = "reactions")
+    val reactions: GithubReactionsDto,
+    @Json(name = "repository_url")
+    val repositoryUrl: String,
+    @Json(name = "state")
+    val state: String,
+    @Json(name = "state_reason")
+    val stateReason: Any?,
+    @Json(name = "timeline_url")
+    val timelineUrl: String,
+    @Json(name = "title")
+    val title: String,
+    @Json(name = "updated_at")
+    val updatedAt: String,
+    @Json(name = "url")
+    val url: String,
+    @Json(name = "user")
+    val user: GithubUserDto
+)

--- a/app/src/main/java/com/github/repo/data/dto/GithubLabelDto.kt
+++ b/app/src/main/java/com/github/repo/data/dto/GithubLabelDto.kt
@@ -1,0 +1,21 @@
+package com.github.repo.data.dto
+
+
+import com.squareup.moshi.Json
+
+data class GithubLabelDto(
+    @Json(name = "color")
+    val color: String,
+    @Json(name = "default")
+    val default: Boolean,
+    @Json(name = "description")
+    val description: String,
+    @Json(name = "id")
+    val id: Long,
+    @Json(name = "name")
+    val name: String,
+    @Json(name = "node_id")
+    val nodeId: String,
+    @Json(name = "url")
+    val url: String
+)

--- a/app/src/main/java/com/github/repo/data/dto/GithubMilestoneDto.kt
+++ b/app/src/main/java/com/github/repo/data/dto/GithubMilestoneDto.kt
@@ -1,0 +1,39 @@
+package com.github.repo.data.dto
+
+
+import com.squareup.moshi.Json
+
+data class GithubMilestoneDto(
+    @Json(name = "closed_at")
+    val closedAt: Any?,
+    @Json(name = "closed_issues")
+    val closedIssues: Int,
+    @Json(name = "created_at")
+    val createdAt: String,
+    @Json(name = "creator")
+    val creator: GithubCreatorDto,
+    @Json(name = "description")
+    val description: String,
+    @Json(name = "due_on")
+    val dueOn: String,
+    @Json(name = "html_url")
+    val htmlUrl: String,
+    @Json(name = "id")
+    val id: Int,
+    @Json(name = "labels_url")
+    val labelsUrl: String,
+    @Json(name = "node_id")
+    val nodeId: String,
+    @Json(name = "number")
+    val number: Int,
+    @Json(name = "open_issues")
+    val openIssues: Int,
+    @Json(name = "state")
+    val state: String,
+    @Json(name = "title")
+    val title: String,
+    @Json(name = "updated_at")
+    val updatedAt: String,
+    @Json(name = "url")
+    val url: String
+)

--- a/app/src/main/java/com/github/repo/data/dto/GithubNotificationDto.kt
+++ b/app/src/main/java/com/github/repo/data/dto/GithubNotificationDto.kt
@@ -4,9 +4,9 @@ import com.squareup.moshi.Json
 
 data class GithubNotificationDto(
     @Json(name = "id") val id: String,
-    @Json(name = "last_read_at") val lastReadAt: String,
+    @Json(name = "last_read_at") val lastReadAt: String?,
     @Json(name = "reason") val reason: String,
-    @Json(name = "repository") val repository: Repository,
+    @Json(name = "repository") val repository: GithubRepositoryDto,
     @Json(name = "subject") val subject: GithubSubjectDto,
     @Json(name = "subscription_url") val subscriptionUrl: String,
     @Json(name = "unread") val unread: Boolean,

--- a/app/src/main/java/com/github/repo/data/dto/GithubReactionsDto.kt
+++ b/app/src/main/java/com/github/repo/data/dto/GithubReactionsDto.kt
@@ -1,0 +1,27 @@
+package com.github.repo.data.dto
+
+
+import com.squareup.moshi.Json
+
+data class GithubReactionsDto(
+    @Json(name = "confused")
+    val confused: Int,
+    @Json(name = "eyes")
+    val eyes: Int,
+    @Json(name = "heart")
+    val heart: Int,
+    @Json(name = "hooray")
+    val hooray: Int,
+    @Json(name = "laugh")
+    val laugh: Int,
+    @Json(name = "rocket")
+    val rocket: Int,
+    @Json(name = "total_count")
+    val totalCount: Int,
+    @Json(name = "url")
+    val url: String,
+    @Json(name = "+1")
+    val plus: Int,
+    @Json(name = "-1")
+    val minus: Int
+)

--- a/app/src/main/java/com/github/repo/data/dto/GithubRepositoryDto.kt
+++ b/app/src/main/java/com/github/repo/data/dto/GithubRepositoryDto.kt
@@ -2,7 +2,7 @@ package com.github.repo.data.dto
 
 import com.squareup.moshi.Json
 
-data class Repository(
+data class GithubRepositoryDto(
     @Json(name = "archive_url") val archiveUrl: String,
     @Json(name = "assignees_url") val assigneesUrl: String,
     @Json(name = "blobs_url") val blobsUrl: String,
@@ -17,13 +17,13 @@ data class Repository(
     @Json(name = "description") val description: String,
     @Json(name = "downloads_url") val downloadsUrl: String,
     @Json(name = "events_url") val eventsUrl: String,
-    @Json(name = "for") val fork: Boolean,
+    @Json(name = "fork") val fork: Boolean,
     @Json(name = "forks_url") val forksUrl: String,
     @Json(name = "full_name") val fullName: String,
     @Json(name = "git_commits_url") val gitCommitsUurl: String,
     @Json(name = "git_refs_url") val gitRefsUrl: String,
     @Json(name = "git_tags_url") val gitTagsUrl: String,
-    @Json(name = "git_url") val gitUrl: String,
+    @Json(name = "git_url") val gitUrl: String?,
     @Json(name = "hooks_url") val hooksUrl: String,
     @Json(name = "html_url") val htmlUrl: String,
     @Json(name = "id") val id: Int,
@@ -42,7 +42,7 @@ data class Repository(
     @Json(name = "private") val private: Boolean,
     @Json(name = "pulls_url") val pullsUrl: String,
     @Json(name = "releases_url") val releasesUrl: String,
-    @Json(name = "ssh_url") val sshUrl: String,
+    @Json(name = "ssh_url") val sshUrl: String?,
     @Json(name = "stargazers_url") val stargazersUrl: String,
     @Json(name = "statuses_url") val statusesUrl: String,
     @Json(name = "subscribers_url") val subscribersUrl: String,

--- a/app/src/main/java/com/github/repo/data/dto/GithubUserDto.kt
+++ b/app/src/main/java/com/github/repo/data/dto/GithubUserDto.kt
@@ -1,0 +1,43 @@
+package com.github.repo.data.dto
+
+
+import com.squareup.moshi.Json
+
+data class GithubUserDto(
+    @Json(name = "avatar_url")
+    val avatarUrl: String,
+    @Json(name = "events_url")
+    val eventsUrl: String,
+    @Json(name = "followers_url")
+    val followersUrl: String,
+    @Json(name = "following_url")
+    val followingUrl: String,
+    @Json(name = "gists_url")
+    val gistsUrl: String,
+    @Json(name = "gravatar_id")
+    val gravatarId: String,
+    @Json(name = "html_url")
+    val htmlUrl: String,
+    @Json(name = "id")
+    val id: Int,
+    @Json(name = "login")
+    val login: String,
+    @Json(name = "node_id")
+    val nodeId: String,
+    @Json(name = "organizations_url")
+    val organizationsUrl: String,
+    @Json(name = "received_events_url")
+    val receivedEventsUrl: String,
+    @Json(name = "repos_url")
+    val reposUrl: String,
+    @Json(name = "site_admin")
+    val siteAdmin: Boolean,
+    @Json(name = "starred_url")
+    val starredUrl: String,
+    @Json(name = "subscriptions_url")
+    val subscriptionsUrl: String,
+    @Json(name = "type")
+    val type: String,
+    @Json(name = "url")
+    val url: String
+)

--- a/app/src/main/java/com/github/repo/data/network/GitHubService.kt
+++ b/app/src/main/java/com/github/repo/data/network/GitHubService.kt
@@ -1,5 +1,6 @@
 package com.github.repo.data.network
 
+import com.github.repo.data.dto.GithubIssueDto
 import com.github.repo.data.dto.GithubSearchDto
 import com.github.repo.data.dto.GithubNotificationDto
 import com.github.repo.data.dto.GithubTokenDto
@@ -20,10 +21,12 @@ interface GitHubService {
     @GET("search/repositories")
     suspend fun searchRepositories(@Query("q") query: String): GithubSearchDto
 
-    @GET("/notifications")
+    @GET("/notifications?all=true")
     suspend fun getNotifications(
         @Header("Authorization") token: String,
         @Header("Accept") accept: String = "Accept: application/vnd.github+json"
     ): List<GithubNotificationDto>
 
+    @GET
+    suspend fun getIssueFromNotification(@Url url: String): GithubIssueDto
 }

--- a/app/src/main/java/com/github/repo/data/repository/GithubRepositoryImpl.kt
+++ b/app/src/main/java/com/github/repo/data/repository/GithubRepositoryImpl.kt
@@ -1,5 +1,7 @@
 package com.github.repo.data.repository
 
+import android.util.Log
+import com.github.repo.config.GITHUB_API
 import com.github.repo.data.datasource.GithubDataSource
 import com.github.repo.data.dto.toGithubSearch
 import com.github.repo.domain.model.GithubSearch
@@ -17,16 +19,22 @@ class GithubRepositoryImpl(private val githubDataSource: GithubDataSource) : Git
                 .onFailure { throw it }
                 .onSuccess { list ->
                     list.forEach {
-                        notificationList.add(
-                            NotificationDto(
-                                thumbnailUrl = it.repository.owner.avatarUrl,
-                                repoName = it.repository.fullName,
-                                notificationTitle = it.subject.title,
-                                issueNumber = 3,
-                                updateTime = it.updatedAt,
-                                commentCount = 2,
-                            )
-                        )
+                        githubDataSource.getIssueFromNotification(it.subject.url)
+                            .onFailure { fail ->
+                                throw fail
+                            }
+                            .onSuccess { dto ->
+                                notificationList.add(
+                                    NotificationDto(
+                                        thumbnailUrl = it.repository.owner.avatarUrl,
+                                        repoName = it.repository.fullName,
+                                        notificationTitle = it.subject.title,
+                                        issueNumber = dto.number,
+                                        updateTime = it.updatedAt,
+                                        commentCount = dto.comments,
+                                    )
+                                )
+                            }
                     }
                 }
             notificationList

--- a/app/src/main/java/com/github/repo/data/repository/GithubRepositoryImpl.kt
+++ b/app/src/main/java/com/github/repo/data/repository/GithubRepositoryImpl.kt
@@ -1,20 +1,18 @@
 package com.github.repo.data.repository
 
-import android.util.Log
-import com.github.repo.config.GITHUB_API
 import com.github.repo.data.datasource.GithubDataSource
 import com.github.repo.data.dto.toGithubSearch
 import com.github.repo.domain.model.GithubSearch
-import com.github.repo.domain.dto.NotificationDto
+import com.github.repo.domain.dto.Notification
 import com.github.repo.domain.repository.GithubRepository
 
 class GithubRepositoryImpl(private val githubDataSource: GithubDataSource) : GithubRepository {
 
     override suspend fun getIssues() {}
 
-    override suspend fun getNotifications(token: String): Result<List<NotificationDto>> =
+    override suspend fun getNotifications(token: String): Result<List<Notification>> =
         runCatching {
-            val notificationList = mutableListOf<NotificationDto>()
+            val notificationList = mutableListOf<Notification>()
             githubDataSource.getNotifications(token)
                 .onFailure { throw it }
                 .onSuccess { list ->
@@ -25,7 +23,7 @@ class GithubRepositoryImpl(private val githubDataSource: GithubDataSource) : Git
                             }
                             .onSuccess { dto ->
                                 notificationList.add(
-                                    NotificationDto(
+                                    Notification(
                                         thumbnailUrl = it.repository.owner.avatarUrl,
                                         repoName = it.repository.fullName,
                                         notificationTitle = it.subject.title,

--- a/app/src/main/java/com/github/repo/domain/dto/Notification.kt
+++ b/app/src/main/java/com/github/repo/domain/dto/Notification.kt
@@ -1,6 +1,6 @@
 package com.github.repo.domain.dto
 
-data class NotificationDto (
+data class Notification (
     val thumbnailUrl: String,
     val repoName: String,
     val notificationTitle: String,

--- a/app/src/main/java/com/github/repo/domain/repository/GithubRepository.kt
+++ b/app/src/main/java/com/github/repo/domain/repository/GithubRepository.kt
@@ -1,12 +1,12 @@
 package com.github.repo.domain.repository
 
 import com.github.repo.domain.model.GithubSearch
-import com.github.repo.domain.dto.NotificationDto
+import com.github.repo.domain.dto.Notification
 
 interface GithubRepository {
 
     suspend fun getIssues()
-    suspend fun getNotifications(token: String): Result<List<NotificationDto>>
+    suspend fun getNotifications(token: String): Result<List<Notification>>
     suspend fun getProfile()
     suspend fun searchRepositories(keyword: String): Result<GithubSearch>
 }

--- a/app/src/main/java/com/github/repo/presentation/main/notifications/NotificationsFragment.kt
+++ b/app/src/main/java/com/github/repo/presentation/main/notifications/NotificationsFragment.kt
@@ -7,9 +7,8 @@ import android.view.ViewGroup
 import androidx.core.view.isGone
 import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
-import androidx.recyclerview.widget.LinearLayoutManager
 import com.github.repo.databinding.FragmentNotificationsBinding
-import com.github.repo.domain.dto.NotificationDto
+import com.github.repo.domain.dto.Notification
 import com.github.repo.presentation.main.notifications.adapter.NotificationAdapter
 import org.koin.androidx.viewmodel.ext.android.viewModel
 
@@ -67,7 +66,7 @@ class NotificationsFragment : Fragment() {
         binding.tvError.isGone = true
     }
 
-    private fun handleSuccess(list: List<NotificationDto>) {
+    private fun handleSuccess(list: List<Notification>) {
         rvAdapter.addItemList(list)
         binding.rvNotification.isVisible = true
         binding.pbLoading.isGone = true

--- a/app/src/main/java/com/github/repo/presentation/main/notifications/NotificationsViewModel.kt
+++ b/app/src/main/java/com/github/repo/presentation/main/notifications/NotificationsViewModel.kt
@@ -1,12 +1,10 @@
 package com.github.repo.presentation.main.notifications
 
-import android.util.Log
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.github.repo.data.datasource.TokenSharedPreference
-import com.github.repo.domain.dto.NotificationDto
 import com.github.repo.domain.repository.GithubRepository
 import kotlinx.coroutines.launch
 

--- a/app/src/main/java/com/github/repo/presentation/main/notifications/NotificationsViewModel.kt
+++ b/app/src/main/java/com/github/repo/presentation/main/notifications/NotificationsViewModel.kt
@@ -21,20 +21,7 @@ class NotificationsViewModel(
     fun getNotifications() = viewModelScope.launch {
         _uiState.value = UiState.Loading
         githubRepository.getNotifications("token ${tokenSharedPreference.getToken()}")
-            .onSuccess { list ->
-                val dummies = listOf(
-                    NotificationDto("https://avatars.githubusercontent.com/u/9919?s=460&v=4","test/repo", "test notification title", 3, "2014-11-07T22:01:45Z",3),
-                    NotificationDto("https://avatars.githubusercontent.com/u/9919?s=460&v=4","test/repo", "test notification title", 3, "2014-11-07T22:01:45Z",3),
-                    NotificationDto("https://avatars.githubusercontent.com/u/9919?s=460&v=4","test/repo", "test notification title", 3, "2014-11-07T22:01:45Z",3),
-                    NotificationDto("https://avatars.githubusercontent.com/u/9919?s=460&v=4","test/repo", "test notification title", 3, "2014-11-07T22:01:45Z",3),
-                    NotificationDto("https://avatars.githubusercontent.com/u/9919?s=460&v=4","test/repo", "test notification title", 3, "2014-11-07T22:01:45Z",3),
-                )
-                _uiState.value = UiState.GetNotifications(dummies)
-            }
-            .onFailure {
-                it.printStackTrace()
-                Log.d("Tester",tokenSharedPreference.getToken())
-                _uiState.value = UiState.Error
-            }
+            .onSuccess { _uiState.value = UiState.GetNotifications(it) }
+            .onFailure { _uiState.value = UiState.Error }
     }
 }

--- a/app/src/main/java/com/github/repo/presentation/main/notifications/UiState.kt
+++ b/app/src/main/java/com/github/repo/presentation/main/notifications/UiState.kt
@@ -1,9 +1,9 @@
 package com.github.repo.presentation.main.notifications
 
-import com.github.repo.domain.dto.NotificationDto
+import com.github.repo.domain.dto.Notification
 
 sealed class UiState {
     object Error : UiState()
     object Loading : UiState()
-    data class GetNotifications(val notificationList: List<NotificationDto>) : UiState()
+    data class GetNotifications(val notificationList: List<Notification>) : UiState()
 }

--- a/app/src/main/java/com/github/repo/presentation/main/notifications/adapter/NotificationAdapter.kt
+++ b/app/src/main/java/com/github/repo/presentation/main/notifications/adapter/NotificationAdapter.kt
@@ -5,15 +5,15 @@ import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView
 import com.bumptech.glide.Glide
 import com.github.repo.databinding.ItemNotificationBinding
-import com.github.repo.domain.dto.NotificationDto
+import com.github.repo.domain.dto.Notification
 import com.github.repo.utils.DateUtils
 import java.util.*
 
 class NotificationAdapter : RecyclerView.Adapter<NotificationAdapter.ViewHolder>() {
 
-    private val notificationDtoList = ArrayList<NotificationDto>()
+    private val notificationDtoList = ArrayList<Notification>()
 
-    fun addItemList(list: List<NotificationDto>) {
+    fun addItemList(list: List<Notification>) {
         notificationDtoList.addAll(list)
         notifyDataSetChanged()
     }
@@ -35,7 +35,7 @@ class NotificationAdapter : RecyclerView.Adapter<NotificationAdapter.ViewHolder>
 
     inner class ViewHolder(val binding: ItemNotificationBinding) :
         RecyclerView.ViewHolder(binding.root) {
-        fun bind(notificationDto: NotificationDto) {
+        fun bind(notificationDto: Notification) {
             Glide.with(binding.root)
                 .load(notificationDto.thumbnailUrl)
                 .into(binding.ivThumbnail)


### PR DESCRIPTION
❗️ 이슈
- close #36

📝 구현한 내용
- Notification에 대한 Issue 데이터 로드
  - Notification에 대한 Issue 데이터 로드
      - comment 개수와 Issue 넘버를 얻기 위해 API 요청을 수행함
      - Notification에서 Issue Url을 그대로 주기에 BaseUrl을 무시하는 url 값을 통해 값을 읽어옴
  - Dto 클래스에 대한 Null 처리
- Notification 데이터 클래스 명 변경
  - 내부에서만 사용할 Data class에 네트워크 통신에 사용되는 Dto 명칭이 부적합하다고 판단.
      - Dto를 제거한 Notification 클래스로 정정함
