### PR TITLE
Notification에서 comment 정보 가져오기 개선

### DIFF
--- a/app/src/main/java/com/github/repo/data/network/GitHubService.kt
+++ b/app/src/main/java/com/github/repo/data/network/GitHubService.kt
@@ -1,8 +1,8 @@
 package com.github.repo.data.network
 
 import com.github.repo.data.dto.GithubIssueDto
-import com.github.repo.data.dto.GithubSearchDto
 import com.github.repo.data.dto.GithubNotificationDto
+import com.github.repo.data.dto.GithubSearchDto
 import com.github.repo.data.dto.GithubTokenDto
 import retrofit2.http.*
 
@@ -24,7 +24,8 @@ interface GitHubService {
     @GET("/notifications")
     suspend fun getNotifications(
         @Header("Authorization") token: String,
-        @Header("Accept") accept: String = "Accept: application/vnd.github+json"
+        @Header("Accept") accept: String = "Accept: application/vnd.github+json",
+        @Query("per_page") perPage: Int = 20
     ): List<GithubNotificationDto>
 
     @GET


### PR DESCRIPTION
❗️ 이슈

- close #55 

📝 구현한 내용

- 기존 Notification에서 반복문에서 결과 값을 가져올 때까지 blocking 상태
  - 반복문에서 각각에 대해 바로 요청을 보낸 후, suspend 함수를 통해 다른 작업 할 수 있도록 수정

- 사용자 입장에서 응답시간을 빨리 해주기 위해서 20개의 목록씩 볼 수 있도록 수정