### PR TITLE
무한 스크롤 처리

### DIFF
--- a/app/src/main/java/com/github/repo/config/XAccessTokenInterceptor.kt
+++ b/app/src/main/java/com/github/repo/config/XAccessTokenInterceptor.kt
@@ -1,6 +1,5 @@
 package com.github.repo.config
 
-import android.util.Log
 import com.github.repo.data.datasource.TokenSharedPreference
 import okhttp3.Interceptor
 import okhttp3.Request

--- a/app/src/main/java/com/github/repo/data/datasource/GithubDataSource.kt
+++ b/app/src/main/java/com/github/repo/data/datasource/GithubDataSource.kt
@@ -5,8 +5,8 @@ import com.github.repo.data.network.GitHubService
 
 class GithubDataSource(private val gitHubService: GitHubService) {
 
-    suspend fun getIssues(state: String): Result<List<GithubIssueDto>> {
-        return runCatching { gitHubService.getIssues(state) }
+    suspend fun getIssues(state: String, page: Int): Result<List<GithubIssueDto>> {
+        return runCatching { gitHubService.getIssues(state, page = page) }
     }
 
     suspend fun searchRepositories(keyword: String, page: Int): Result<GithubSearchDto> {

--- a/app/src/main/java/com/github/repo/data/datasource/GithubDataSource.kt
+++ b/app/src/main/java/com/github/repo/data/datasource/GithubDataSource.kt
@@ -11,7 +11,7 @@ class GithubDataSource(private val gitHubService: GitHubService) {
 
     suspend fun searchRepositories(keyword: String, page: Int): Result<GithubSearchDto> {
         return runCatching {
-            gitHubService.searchRepositories(keyword, page)
+            gitHubService.searchRepositories(keyword, page = page)
         }
     }
 

--- a/app/src/main/java/com/github/repo/data/datasource/GithubDataSource.kt
+++ b/app/src/main/java/com/github/repo/data/datasource/GithubDataSource.kt
@@ -9,14 +9,14 @@ class GithubDataSource(private val gitHubService: GitHubService) {
         return runCatching { gitHubService.getIssues(state) }
     }
 
-    suspend fun searchRepositories(keyword: String): Result<GithubSearchDto> {
+    suspend fun searchRepositories(keyword: String, page: Int): Result<GithubSearchDto> {
         return runCatching {
-            gitHubService.searchRepositories(keyword)
+            gitHubService.searchRepositories(keyword, page)
         }
     }
 
-    suspend fun getNotifications(): Result<List<GithubNotificationDto>> =
-        runCatching { gitHubService.getNotifications() }
+    suspend fun getNotifications(page: Int): Result<List<GithubNotificationDto>> =
+        runCatching { gitHubService.getNotifications(page = page) }
 
     suspend fun getIssueFromNotification(url: String): Result<GithubIssueDto> =
         runCatching { gitHubService.getIssueFromNotification(url) }

--- a/app/src/main/java/com/github/repo/data/dto/GithubIssueDto.kt
+++ b/app/src/main/java/com/github/repo/data/dto/GithubIssueDto.kt
@@ -8,7 +8,7 @@ data class GithubIssueDto(
     @Json(name = "assignee") val assignee: GithubAssigneeDto?,
     @Json(name = "assignees") val assignees: List<GithubAssigneeDto>,
     @Json(name = "author_association") val authorAssociation: String,
-    @Json(name = "body") val body: String,
+    @Json(name = "body") val body: String?,
     @Json(name = "closed_at") val closedAt: String?,
     @Json(name = "closed_by") val closedBy: Any?,
     @Json(name = "comments") val comments: Int,

--- a/app/src/main/java/com/github/repo/data/dto/GithubOrganizationDto.kt
+++ b/app/src/main/java/com/github/repo/data/dto/GithubOrganizationDto.kt
@@ -1,5 +1,5 @@
 package com.github.repo.data.dto
 
-data class GithubOrganizationDto (
+data class GithubOrganizationDto(
     val id: Int
 )

--- a/app/src/main/java/com/github/repo/data/dto/GithubStarredDto.kt
+++ b/app/src/main/java/com/github/repo/data/dto/GithubStarredDto.kt
@@ -1,5 +1,5 @@
 package com.github.repo.data.dto
 
-data class GithubStarredDto (
+data class GithubStarredDto(
     val id: Int
 )

--- a/app/src/main/java/com/github/repo/data/network/GitHubService.kt
+++ b/app/src/main/java/com/github/repo/data/network/GitHubService.kt
@@ -22,10 +22,15 @@ interface GitHubService {
     ): List<GithubIssueDto>
 
     @GET("search/repositories")
-    suspend fun searchRepositories(@Query("q") query: String): GithubSearchDto
+    suspend fun searchRepositories(
+        @Query("q") query: String,
+        @Query("page") page: Int,
+        @Query("per_page") perPage: Int = 20
+    ): GithubSearchDto
 
     @GET("/notifications")
     suspend fun getNotifications(
+        @Query("page") page: Int,
         @Query("per_page") perPage: Int = 20
     ): List<GithubNotificationDto>
 

--- a/app/src/main/java/com/github/repo/data/network/GitHubService.kt
+++ b/app/src/main/java/com/github/repo/data/network/GitHubService.kt
@@ -1,13 +1,13 @@
 package com.github.repo.data.network
 
 import com.github.repo.data.dto.*
+import com.github.repo.presentation.common.RecyclerViewScrollMediator
 import retrofit2.http.*
 
 interface GitHubService {
 
     @FormUrlEncoded
     @POST("login/oauth/access_token")
-    @Headers("Accept: application/json")
     suspend fun getAccessToken(
         @Field("client_id") clientId: String,
         @Field("client_secret") clientSecret: String,
@@ -17,7 +17,7 @@ interface GitHubService {
     @GET("user/issues")
     suspend fun getIssues(
         @Query("state") state: String,
-        @Query("per_page") perPage: Int = 20,
+        @Query("per_page") perPage: Int = RecyclerViewScrollMediator.perPage,
         @Query("page") page: Int = 1,
     ): List<GithubIssueDto>
 
@@ -25,13 +25,13 @@ interface GitHubService {
     suspend fun searchRepositories(
         @Query("q") query: String,
         @Query("page") page: Int,
-        @Query("per_page") perPage: Int = 20
+        @Query("per_page") perPage: Int = RecyclerViewScrollMediator.perPage,
     ): GithubSearchDto
 
     @GET("/notifications")
     suspend fun getNotifications(
         @Query("page") page: Int,
-        @Query("per_page") perPage: Int = 20
+        @Query("per_page") perPage: Int = RecyclerViewScrollMediator.perPage,
     ): List<GithubNotificationDto>
 
     @GET

--- a/app/src/main/java/com/github/repo/data/repository/GithubRepositoryImpl.kt
+++ b/app/src/main/java/com/github/repo/data/repository/GithubRepositoryImpl.kt
@@ -1,11 +1,10 @@
 package com.github.repo.data.repository
 
-import android.util.Log
 import com.github.repo.data.datasource.GithubDataSource
 import com.github.repo.data.dto.toGithubIssue
 import com.github.repo.data.dto.toGithubSearch
-import com.github.repo.domain.model.GithubIssue
 import com.github.repo.data.dto.toProfile
+import com.github.repo.domain.model.GithubIssue
 import com.github.repo.domain.model.GithubSearch
 import com.github.repo.domain.model.Notification
 import com.github.repo.domain.model.Profile
@@ -19,9 +18,9 @@ class GithubRepositoryImpl(private val githubDataSource: GithubDataSource) : Git
         return runCatching { issues.map { it.toGithubIssue() } }
     }
 
-    override suspend fun getNotifications(): Result<List<Notification>> {
+    override suspend fun getNotifications(page: Int): Result<List<Notification>> {
         val updatedNotification = mutableListOf<Notification>()
-        val notificationList = githubDataSource.getNotifications().getOrThrow()
+        val notificationList = githubDataSource.getNotifications(page).getOrThrow()
         return withContext(CoroutineScope(Dispatchers.Main.immediate).coroutineContext) {
             notificationList.forEach { notification ->
                 launch {
@@ -45,8 +44,13 @@ class GithubRepositoryImpl(private val githubDataSource: GithubDataSource) : Git
         }
     }
 
-    override suspend fun removeNotification(id: String): Result<Unit> =
-        githubDataSource.removeNotification(id)
+    override suspend fun removeNotification(cache: List<String>) {
+        CoroutineScope(Dispatchers.IO).launch {
+            cache.forEach {
+                launch { githubDataSource.removeNotification(it) }
+            }
+        }
+    }
 
     override suspend fun getMyProfile(): Result<Profile> {
         val data = githubDataSource.getMyProfile().getOrThrow()
@@ -58,11 +62,16 @@ class GithubRepositoryImpl(private val githubDataSource: GithubDataSource) : Git
         val starredCount = starJob.await()
         val organizationCount = organJob.await()
 
-        return runCatching { data.toProfile(organCount = organizationCount, starCount = starredCount) }
+        return runCatching {
+            data.toProfile(
+                organCount = organizationCount,
+                starCount = starredCount
+            )
+        }
     }
 
-    override suspend fun searchRepositories(keyword: String): Result<GithubSearch> {
-        return githubDataSource.searchRepositories(keyword).map {
+    override suspend fun searchRepositories(keyword: String, page: Int): Result<GithubSearch> {
+        return githubDataSource.searchRepositories(keyword, page).map {
             it.toGithubSearch()
         }
     }

--- a/app/src/main/java/com/github/repo/data/repository/GithubRepositoryImpl.kt
+++ b/app/src/main/java/com/github/repo/data/repository/GithubRepositoryImpl.kt
@@ -13,8 +13,8 @@ import kotlinx.coroutines.*
 
 class GithubRepositoryImpl(private val githubDataSource: GithubDataSource) : GithubRepository {
 
-    override suspend fun getIssues(state: String): Result<List<GithubIssue>> {
-        val issues = githubDataSource.getIssues(state).getOrDefault(emptyList())
+    override suspend fun getIssues(state: String, page: Int): Result<List<GithubIssue>> {
+        val issues = githubDataSource.getIssues(state, page = page).getOrThrow()
         return runCatching { issues.map { it.toGithubIssue() } }
     }
 

--- a/app/src/main/java/com/github/repo/domain/model/Profile.kt
+++ b/app/src/main/java/com/github/repo/domain/model/Profile.kt
@@ -1,6 +1,6 @@
 package com.github.repo.domain.model
 
-data class Profile (
+data class Profile(
     val profileImgUrl: String,
     val userName: String,
     val id: String,

--- a/app/src/main/java/com/github/repo/domain/repository/GithubRepository.kt
+++ b/app/src/main/java/com/github/repo/domain/repository/GithubRepository.kt
@@ -8,8 +8,8 @@ import com.github.repo.domain.model.Profile
 interface GithubRepository {
 
     suspend fun getIssues(state: String): Result<List<GithubIssue>>
-    suspend fun getNotifications(): Result<List<Notification>>
+    suspend fun getNotifications(page: Int): Result<List<Notification>>
     suspend fun getMyProfile(): Result<Profile>
-    suspend fun searchRepositories(keyword: String): Result<GithubSearch>
-    suspend fun removeNotification(id: String): Result<Unit>
+    suspend fun removeNotification(cache: List<String>)
+    suspend fun searchRepositories(keyword: String, page: Int): Result<GithubSearch>
 }

--- a/app/src/main/java/com/github/repo/domain/repository/GithubRepository.kt
+++ b/app/src/main/java/com/github/repo/domain/repository/GithubRepository.kt
@@ -7,7 +7,7 @@ import com.github.repo.domain.model.Profile
 
 interface GithubRepository {
 
-    suspend fun getIssues(state: String): Result<List<GithubIssue>>
+    suspend fun getIssues(state: String, page: Int): Result<List<GithubIssue>>
     suspend fun getNotifications(page: Int): Result<List<Notification>>
     suspend fun getMyProfile(): Result<Profile>
     suspend fun removeNotification(cache: List<String>)

--- a/app/src/main/java/com/github/repo/presentation/common/RecyclerViewScrollMediator.kt
+++ b/app/src/main/java/com/github/repo/presentation/common/RecyclerViewScrollMediator.kt
@@ -1,0 +1,51 @@
+package com.github.repo.presentation.common
+
+import android.util.Log
+import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.RecyclerView
+
+class RecyclerViewScrollMediator(
+    private val recyclerView: RecyclerView,
+    private val nextPage: (Int) -> Unit
+) : RecyclerView.OnScrollListener() {
+    private var page = 1
+    private val perPage = 20
+
+    init {
+        recyclerView.addOnScrollListener(this)
+    }
+
+    override fun onScrolled(scrolledRv: RecyclerView, dx: Int, dy: Int) {
+        super.onScrolled(scrolledRv, dx, dy)
+        Log.d("Tester", "check")
+        if (checkPagingEnd(recyclerView.adapter!!.itemCount)) {
+            Log.d("Tester", "${perPage * page} : ${recyclerView.adapter!!.itemCount}")
+            return
+        }
+
+        val lastVisibleItemPosition =
+            (scrolledRv.layoutManager as LinearLayoutManager?)!!.findLastCompletelyVisibleItemPosition()
+        val itemTotalCount = scrolledRv.adapter!!.itemCount - 1
+        Log.d("Tester", "start")
+        // 스크롤이 끝에 도달했는지 확인
+        if (!recyclerView.canScrollVertically(1) && lastVisibleItemPosition == itemTotalCount) {
+            Log.d("Tester", "scorll")
+            nextPage(++page)
+        }
+    }
+
+    // 지금까지 불러온 리스트의 개수와 실제로 불러온 리스트 개수를 비교한다.
+    // 만일 적다면, 더 이상 페이지를 불러올 필요가 없다.
+    // 만일 크거나 같다면, 다음 페이지를 불러올 수 있다. (하지만, 클 순 없음을 보장함)
+    // 따라서, 실제로 불러온 리스트의 개수와 호출된 리스트의 개수를 다른지를 판별함
+    private fun checkPagingEnd(count: Int): Boolean {
+        val totCount = (perPage * page)
+        if (totCount < count)
+            ++page
+        return (totCount != count)
+    }
+
+    fun initialize() {
+        page = 1
+    }
+}

--- a/app/src/main/java/com/github/repo/presentation/common/RecyclerViewScrollMediator.kt
+++ b/app/src/main/java/com/github/repo/presentation/common/RecyclerViewScrollMediator.kt
@@ -1,6 +1,5 @@
 package com.github.repo.presentation.common
 
-import android.util.Log
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 
@@ -9,7 +8,6 @@ class RecyclerViewScrollMediator(
     private val nextPage: (Int) -> Unit
 ) : RecyclerView.OnScrollListener() {
     private var page = 1
-    private val perPage = 20
 
     init {
         recyclerView.addOnScrollListener(this)
@@ -17,27 +15,21 @@ class RecyclerViewScrollMediator(
 
     override fun onScrolled(scrolledRv: RecyclerView, dx: Int, dy: Int) {
         super.onScrolled(scrolledRv, dx, dy)
-        Log.d("Tester", "check")
-        if (checkPagingEnd(recyclerView.adapter!!.itemCount)) {
-            Log.d("Tester", "${perPage * page} : ${recyclerView.adapter!!.itemCount}")
-            return
-        }
+        if (checkPagingEnd(recyclerView.adapter!!.itemCount)) return
 
         val lastVisibleItemPosition =
             (scrolledRv.layoutManager as LinearLayoutManager?)!!.findLastCompletelyVisibleItemPosition()
         val itemTotalCount = scrolledRv.adapter!!.itemCount - 1
-        Log.d("Tester", "start")
-        // 스크롤이 끝에 도달했는지 확인
         if (!recyclerView.canScrollVertically(1) && lastVisibleItemPosition == itemTotalCount) {
-            Log.d("Tester", "scorll")
             nextPage(++page)
         }
     }
 
-    // 지금까지 불러온 리스트의 개수와 실제로 불러온 리스트 개수를 비교한다.
-    // 만일 적다면, 더 이상 페이지를 불러올 필요가 없다.
-    // 만일 크거나 같다면, 다음 페이지를 불러올 수 있다. (하지만, 클 순 없음을 보장함)
-    // 따라서, 실제로 불러온 리스트의 개수와 호출된 리스트의 개수를 다른지를 판별함
+    /**
+     * @description 리스트의 개수와 실제 데이터 개수 비교 (실제로 불러온 데이터의 개수와 호출된 리스트의 개수를 판별)
+     * 적은 경우 : 추가 데이터 호출 불필요
+     * 크거나 같은 경우 : 추가 데이터 호출 가능
+     */
     private fun checkPagingEnd(count: Int): Boolean {
         val totCount = (perPage * page)
         if (totCount < count)
@@ -47,5 +39,9 @@ class RecyclerViewScrollMediator(
 
     fun initialize() {
         page = 1
+    }
+
+    companion object {
+        const val perPage = 20
     }
 }

--- a/app/src/main/java/com/github/repo/presentation/main/issue/IssueFragment.kt
+++ b/app/src/main/java/com/github/repo/presentation/main/issue/IssueFragment.kt
@@ -13,6 +13,7 @@ import androidx.recyclerview.widget.DividerItemDecoration
 import com.github.repo.R
 import com.github.repo.databinding.FragmentIssueBinding
 import com.github.repo.domain.model.GithubIssue
+import com.github.repo.presentation.common.RecyclerViewScrollMediator
 import com.github.repo.presentation.common.onError
 import com.github.repo.presentation.common.onLoading
 import com.github.repo.presentation.common.onSuccess
@@ -51,6 +52,13 @@ class IssueFragment : Fragment() {
 
     private fun adapterSetting() {
         binding.rvIssue.adapter = issueAdapter
+        RecyclerViewScrollMediator(binding.rvIssue) { page ->
+            when (binding.spinnerIssueFilter.selectedItemPosition) {
+                OPEN.position -> viewModel.getIssues(OPEN.optionName, page)
+                CLOSED.position -> viewModel.getIssues(CLOSED.optionName, page)
+                ALL.position -> viewModel.getIssues(ALL.optionName, page)
+            }
+        }
         val dividerItemDecoration = DividerItemDecoration(context, DividerItemDecoration.VERTICAL)
         ContextCompat.getDrawable(requireContext(), R.drawable.recylerview_divider)?.let {
             dividerItemDecoration.setDrawable(it)

--- a/app/src/main/java/com/github/repo/presentation/main/issue/IssueFragment.kt
+++ b/app/src/main/java/com/github/repo/presentation/main/issue/IssueFragment.kt
@@ -28,6 +28,7 @@ class IssueFragment : Fragment() {
     private val viewModel: IssueViewModel by viewModel()
     private lateinit var spinnerAdapter: SpinnerAdapter
     private val issueAdapter = IssueAdapter()
+    private lateinit var recyclerViewScrollMediator: RecyclerViewScrollMediator
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -52,7 +53,7 @@ class IssueFragment : Fragment() {
 
     private fun adapterSetting() {
         binding.rvIssue.adapter = issueAdapter
-        RecyclerViewScrollMediator(binding.rvIssue) { page ->
+        recyclerViewScrollMediator = RecyclerViewScrollMediator(binding.rvIssue) { page ->
             when (binding.spinnerIssueFilter.selectedItemPosition) {
                 OPEN.position -> viewModel.getIssues(OPEN.optionName, page)
                 CLOSED.position -> viewModel.getIssues(CLOSED.optionName, page)
@@ -108,7 +109,6 @@ class IssueFragment : Fragment() {
 
     private fun handleLoading() {
         binding.pbLoading.isVisible = true
-        binding.rvIssue.isGone = true
         binding.tvError.isGone = true
     }
 
@@ -140,6 +140,7 @@ class IssueFragment : Fragment() {
                     parent: AdapterView<*>?, view: View?, position: Int, id: Long
                 ) {
                     viewModel.setSelectedPosition(position)
+                    recyclerViewScrollMediator.initialize()
                     when (position) {
                         OPEN.position -> viewModel.getIssues(OPEN.optionName)
                         CLOSED.position -> viewModel.getIssues(CLOSED.optionName)

--- a/app/src/main/java/com/github/repo/presentation/main/issue/IssueViewModel.kt
+++ b/app/src/main/java/com/github/repo/presentation/main/issue/IssueViewModel.kt
@@ -7,6 +7,7 @@ import androidx.lifecycle.viewModelScope
 import com.github.repo.domain.model.GithubIssue
 import com.github.repo.domain.repository.GithubRepository
 import com.github.repo.presentation.common.UiState
+import com.github.repo.presentation.common.onSuccess
 import com.github.repo.presentation.main.issue.OptionType.OPEN
 import kotlinx.coroutines.launch
 
@@ -23,16 +24,36 @@ class IssueViewModel(
     private val _uiState = MutableLiveData<UiState<List<GithubIssue>>>()
     val uiState: LiveData<UiState<List<GithubIssue>>> = _uiState
 
+    private var prevList: List<GithubIssue> = emptyList()
+    private var prevState: String = OptionType.OPEN.optionName
+
     fun getIssues(state: String, page: Int = 1) = viewModelScope.launch {
+        if (prevState != state) {
+            prevList = emptyList()
+            prevState = state
+            _uiState.value = UiState.Loading
+        }
+
+        _uiState.value?.onSuccess { prevList = it }
+
         _uiState.value = UiState.Loading
-        repository.getIssues(state)
-            .onSuccess {
-                _uiState.value = UiState.Success(it)
+        repository.getIssues(state, page)
+            .onSuccess { data ->
+                if (prevList.isEmpty()) {
+                    _uiState.value = UiState.Success(data)
+                    return@launch
+                }
+                _uiState.value = UiState.Success(prevList)
+                _uiState.value?.onSuccess {
+                    val list = it.toMutableList()
+                    list.addAll(data)
+                    _uiState.value = UiState.Success(list.toList())
+                }
             }
             .onFailure { _uiState.value = UiState.Error }
     }
 
     fun setSelectedPosition(position: Int) {
-        _selectedPosition.value = OptionType.value(position) ?: return
+        _selectedPosition.value = position
     }
 }

--- a/app/src/main/java/com/github/repo/presentation/main/issue/IssueViewModel.kt
+++ b/app/src/main/java/com/github/repo/presentation/main/issue/IssueViewModel.kt
@@ -52,30 +52,6 @@ class IssueViewModel(
             }
             .onFailure { _uiState.value = UiState.Error }
     }
-    /*
-    fun getNextPage(page: Int) = viewModelScope.launch {
-    Log.d("success:nextPage", page.toString())
-    _uiState.value?.onSuccess { it ->
-        prevList = it
-    }
-    _uiState.value = UiState.Loading
-    githubRepository.searchRepositories(searchKeyword.value, page)
-        .onSuccess { data ->
-            Log.d("success:nextPage", data.toString())
-            _uiState.value = UiState.Success(prevList)
-            _uiState.value?.onSuccess { it ->
-                Log.d("success:nextPage", it.toString())
-                val list = it.items.toMutableList()
-                list.addAll(data.items)
-                _uiState.value = UiState.Success(it.copy(items = list))
-            }
-        }
-        .onFailure {
-            Log.d("Tester", it.toString())
-        }
-}
-
-     */
 
     fun setSelectedPosition(position: Int) {
         _selectedPosition.value = position

--- a/app/src/main/java/com/github/repo/presentation/main/issue/IssueViewModel.kt
+++ b/app/src/main/java/com/github/repo/presentation/main/issue/IssueViewModel.kt
@@ -52,6 +52,30 @@ class IssueViewModel(
             }
             .onFailure { _uiState.value = UiState.Error }
     }
+    /*
+    fun getNextPage(page: Int) = viewModelScope.launch {
+    Log.d("success:nextPage", page.toString())
+    _uiState.value?.onSuccess { it ->
+        prevList = it
+    }
+    _uiState.value = UiState.Loading
+    githubRepository.searchRepositories(searchKeyword.value, page)
+        .onSuccess { data ->
+            Log.d("success:nextPage", data.toString())
+            _uiState.value = UiState.Success(prevList)
+            _uiState.value?.onSuccess { it ->
+                Log.d("success:nextPage", it.toString())
+                val list = it.items.toMutableList()
+                list.addAll(data.items)
+                _uiState.value = UiState.Success(it.copy(items = list))
+            }
+        }
+        .onFailure {
+            Log.d("Tester", it.toString())
+        }
+}
+
+     */
 
     fun setSelectedPosition(position: Int) {
         _selectedPosition.value = position

--- a/app/src/main/java/com/github/repo/presentation/main/issue/IssueViewModel.kt
+++ b/app/src/main/java/com/github/repo/presentation/main/issue/IssueViewModel.kt
@@ -23,7 +23,7 @@ class IssueViewModel(
     private val _uiState = MutableLiveData<UiState<List<GithubIssue>>>()
     val uiState: LiveData<UiState<List<GithubIssue>>> = _uiState
 
-    fun getIssues(state: String) = viewModelScope.launch {
+    fun getIssues(state: String, page: Int = 1) = viewModelScope.launch {
         _uiState.value = UiState.Loading
         repository.getIssues(state)
             .onSuccess {

--- a/app/src/main/java/com/github/repo/presentation/main/notifications/NotificationsFragment.kt
+++ b/app/src/main/java/com/github/repo/presentation/main/notifications/NotificationsFragment.kt
@@ -1,7 +1,6 @@
 package com.github.repo.presentation.main.notifications
 
 import android.os.Bundle
-import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -42,7 +41,6 @@ class NotificationsFragment : Fragment() {
     }
 
     override fun onStop() {
-        Log.d("Tester", "onStop: hi")
         super.onStop()
         viewModel.removeNotification()
     }

--- a/app/src/main/java/com/github/repo/presentation/main/notifications/NotificationsViewModel.kt
+++ b/app/src/main/java/com/github/repo/presentation/main/notifications/NotificationsViewModel.kt
@@ -1,6 +1,5 @@
 package com.github.repo.presentation.main.notifications
 
-import android.util.Log
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
@@ -16,17 +15,20 @@ class NotificationsViewModel(
 
     private val _uiState = MutableLiveData<UiState<List<Notification>>>()
     val uiState: LiveData<UiState<List<Notification>>> = _uiState
+    private val cache = mutableListOf<String>()
 
-    fun getNotifications() = viewModelScope.launch {
+    fun getNotifications(page: Int) = viewModelScope.launch {
         _uiState.value = UiState.Loading
-        githubRepository.getNotifications()
+        githubRepository.getNotifications(page)
             .onSuccess { _uiState.value = UiState.Success(it) }
             .onFailure { _uiState.value = UiState.Error }
     }
 
-    fun removeNotification(id: String) = viewModelScope.launch {
-        githubRepository.removeNotification(id)
-            .onSuccess { Log.d("Tester", "Success") }
-            .onFailure { it.printStackTrace() }
+    fun addToRemoveCache(id: String) {
+        cache.add(id)
+    }
+
+    fun removeNotification() = viewModelScope.launch {
+        githubRepository.removeNotification(cache)
     }
 }

--- a/app/src/main/java/com/github/repo/presentation/profile/custom/CustomProfileUserInfoItem.kt
+++ b/app/src/main/java/com/github/repo/presentation/profile/custom/CustomProfileUserInfoItem.kt
@@ -2,12 +2,8 @@ package com.github.repo.presentation.profile.custom
 
 import android.content.Context
 import android.util.AttributeSet
-import android.util.Log
 import android.view.LayoutInflater
-import android.widget.TextView
 import android.widget.Toolbar
-import androidx.core.content.res.getStringOrThrow
-import androidx.databinding.BindingAdapter
 import androidx.databinding.DataBindingUtil
 import com.github.repo.R
 import com.github.repo.databinding.ViewProfileUserInfoItemBinding

--- a/app/src/main/java/com/github/repo/presentation/search/SearchFragment.kt
+++ b/app/src/main/java/com/github/repo/presentation/search/SearchFragment.kt
@@ -128,7 +128,6 @@ class SearchFragment : Fragment() {
     }
 
     private fun handleLoading() {
-        //binding.rvRepository.isVisible = false
         binding.pbLoading.isVisible = true
         binding.layoutBlank.isVisible = false
     }

--- a/app/src/main/java/com/github/repo/presentation/search/SearchFragment.kt
+++ b/app/src/main/java/com/github/repo/presentation/search/SearchFragment.kt
@@ -17,10 +17,7 @@ import androidx.recyclerview.widget.DividerItemDecoration
 import com.github.repo.R
 import com.github.repo.databinding.FragmentSearchBinding
 import com.github.repo.domain.model.GithubSearch
-import com.github.repo.presentation.common.Clickable
-import com.github.repo.presentation.common.onError
-import com.github.repo.presentation.common.onLoading
-import com.github.repo.presentation.common.onSuccess
+import com.github.repo.presentation.common.*
 import com.github.repo.presentation.search.adapter.RepositoryAdapter
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.FlowPreview
@@ -30,6 +27,7 @@ class SearchFragment : Fragment() {
 
     private lateinit var binding: FragmentSearchBinding
     private lateinit var listener: Clickable
+    private lateinit var rvScrollManager: RecyclerViewScrollMediator
     private val viewModel by sharedViewModel<SearchViewModel>()
     private val imm: InputMethodManager by lazy { activity?.getSystemService(INPUT_METHOD_SERVICE) as InputMethodManager }
     private val adapter = RepositoryAdapter()
@@ -91,6 +89,9 @@ class SearchFragment : Fragment() {
 
     private fun adapterSetting() {
         binding.rvRepository.adapter = adapter
+        rvScrollManager = RecyclerViewScrollMediator(binding.rvRepository) { page ->
+            viewModel.getNextPage(page)
+        }
         val dividerItemDecoration = DividerItemDecoration(context, DividerItemDecoration.VERTICAL)
         ContextCompat.getDrawable(requireContext(), R.drawable.recylerview_divider)?.let {
             dividerItemDecoration.setDrawable(it)
@@ -127,7 +128,7 @@ class SearchFragment : Fragment() {
     }
 
     private fun handleLoading() {
-        binding.rvRepository.isVisible = false
+        //binding.rvRepository.isVisible = false
         binding.pbLoading.isVisible = true
         binding.layoutBlank.isVisible = false
     }
@@ -136,6 +137,7 @@ class SearchFragment : Fragment() {
         binding.rvRepository.isVisible = false
         binding.pbLoading.isVisible = false
         binding.layoutBlank.isVisible = true
+        rvScrollManager.initialize()
     }
 
     private fun hideKeyboard() {

--- a/app/src/main/java/com/github/repo/presentation/search/SearchViewModel.kt
+++ b/app/src/main/java/com/github/repo/presentation/search/SearchViewModel.kt
@@ -1,38 +1,64 @@
 package com.github.repo.presentation.search
 
-import androidx.lifecycle.ViewModel
-import androidx.lifecycle.asLiveData
+import android.util.Log
+import androidx.lifecycle.*
+import com.github.repo.domain.model.GithubSearch
 import com.github.repo.domain.repository.GithubRepository
 import com.github.repo.presentation.common.UiState
-import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.FlowPreview
+import com.github.repo.presentation.common.onSuccess
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.mapLatest
+import kotlinx.coroutines.launch
 
 class SearchViewModel(
     private val githubRepository: GithubRepository,
 ) : ViewModel() {
 
     val searchKeyword = MutableStateFlow(BLANK)
+    lateinit var prevList: GithubSearch
 
-    @ExperimentalCoroutinesApi
-    @FlowPreview
-    val uiState = searchKeyword
+    private val _uiState = searchKeyword
         .debounce(300)
         .mapLatest { query ->
             if (query.isBlank()) {
                 UiState.Error
             } else {
-                val githubSearch = githubRepository.searchRepositories(query).getOrNull()
+
+                val githubSearch =
+                    githubRepository.searchRepositories(query, 1).getOrNull()
                 githubSearch?.let {
                     UiState.Success(it)
                 } ?: UiState.Error
             }
-        }.asLiveData()
+        }.asLiveData() as MutableLiveData
+    val uiState: LiveData<UiState<GithubSearch>> = _uiState
 
     fun clearKeyword() {
         searchKeyword.value = BLANK
+    }
+
+    fun getNextPage(page: Int) = viewModelScope.launch {
+        Log.d("success:nextPage", page.toString())
+        _uiState.value?.onSuccess { it ->
+            prevList = it
+        }
+        _uiState.value = UiState.Loading
+        githubRepository.searchRepositories(searchKeyword.value, page)
+            .onSuccess { data ->
+                Log.d("success:nextPage", data.toString())
+                _uiState.value = UiState.Success(prevList)
+                _uiState.value?.onSuccess { it ->
+                    Log.d("success:nextPage", it.toString())
+                    val list = it.items.toMutableList()
+                    list.addAll(data.items)
+                    _uiState.value = UiState.Success(it.copy(items = list))
+                }
+            }
+            .onFailure {
+                Log.d("Tester", it.toString())
+                _uiState.value = UiState.Error
+            }
     }
 
     companion object {

--- a/app/src/main/java/com/github/repo/presentation/search/SearchViewModel.kt
+++ b/app/src/main/java/com/github/repo/presentation/search/SearchViewModel.kt
@@ -1,6 +1,5 @@
 package com.github.repo.presentation.search
 
-import android.util.Log
 import androidx.lifecycle.*
 import com.github.repo.domain.model.GithubSearch
 import com.github.repo.domain.repository.GithubRepository
@@ -39,24 +38,20 @@ class SearchViewModel(
     }
 
     fun getNextPage(page: Int) = viewModelScope.launch {
-        Log.d("success:nextPage", page.toString())
         _uiState.value?.onSuccess { it ->
             prevList = it
         }
         _uiState.value = UiState.Loading
         githubRepository.searchRepositories(searchKeyword.value, page)
             .onSuccess { data ->
-                Log.d("success:nextPage", data.toString())
                 _uiState.value = UiState.Success(prevList)
                 _uiState.value?.onSuccess { it ->
-                    Log.d("success:nextPage", it.toString())
                     val list = it.items.toMutableList()
                     list.addAll(data.items)
                     _uiState.value = UiState.Success(it.copy(items = list))
                 }
             }
             .onFailure {
-                Log.d("Tester", it.toString())
                 _uiState.value = UiState.Error
             }
     }


### PR DESCRIPTION
❗️ 이슈
- close #72 
- close #44 

📝 구현한 내용

- Search 프래그먼트 페이징 처리 적용
    - 스크롤 시 로딩 화면을 띄우며 새로운 데이터를 로드한다.
    - 모든 데이터가 불러와졌을 땐 더이상의 호출을 하지 않으며
    - 새로운 검색을 띄우게 되면 페이징을 처음부터 시작한다.

-  Notification 프래그먼트 페이징 처리 적용
    - 스크롤 시 로딩 화면을 띄우며 새로운 데이터를 로드한다.
    - Swipe 처리 시 데이터를 즉시 지우지 않으며 캐싱처리한 후, 페이징을 지속한다.
    - Notification 화면을 벗어날 때 캐시처리된 데이터들을 백그라운드 단에서 알림 읽음 처리를 서버에 전송한다.

- Issue 프래그먼트 페이징 처리 적용
    - Option 타입에 따른 페이징 개별 처리
        - Option 변화에 따른 페이징 초기화
    - 스크롤 시 로딩 화면을 띄우며 새로운 데이터를 로드한다.
    - 모든 데이터가 불러와졌을 땐 더이상의 호출을 하지 않으며
    - 새로운 검색을 띄우게 되면 페이징을 처음부터 시작한다.